### PR TITLE
SB Gift Message

### DIFF
--- a/src/modules/shout.ts
+++ b/src/modules/shout.ts
@@ -413,6 +413,12 @@ class GiftButton implements Feature {
             const target = e.target as HTMLElement;
             //add the Triple Dot Menu as an element
             const sbMenuElem = target!.closest('.sb_menu');
+			//find the message div
+			const sbMenuParent = target!.closest(`div`);
+			//get the full text of the message div
+			var giftMessage = sbMenuParent!.innerText;
+			//format message with standard text + message contents + server time of the message
+			giftMessage = `Sent on Shoutbox message: "`+ giftMessage.substring(giftMessage.indexOf(": ")+2)+ `" at `+giftMessage.substring(0,8);
             //if the target of the click is not the Triple Dot Menu OR
             //if menu is one of your own comments (only works for first 10 minutes of comment being sent)
             if (
@@ -460,7 +466,8 @@ class GiftButton implements Feature {
                 //begin setting up the GET request to MAM JSON
                 const giftHTTP = new XMLHttpRequest();
                 //URL to GET results with the amount entered by user plus the username found on the menu selected
-                const url = `https://www.myanonamouse.net/json/bonusBuy.php?spendtype=gift&amount=${giftFinalAmount}&giftTo=${userName}`;
+				//added message contents encoded to prevent unintended characters from breaking JSON URL
+                const url = `https://www.myanonamouse.net/json/bonusBuy.php?spendtype=gift&amount=${giftFinalAmount}&giftTo=${userName}&message=${encodeURIComponent(giftMessage)}`;
                 giftHTTP.open('GET', url, true);
                 giftHTTP.setRequestHeader('Content-Type', 'application/json');
                 giftHTTP.onreadystatechange = function () {


### PR DESCRIPTION
Added functionality to utilize Message parameter to indicate which message the gift was sent from - as is, this is a default setting with no opt-in or opt-out ability This is to resolve issue #142 