### PR TITLE
Update selector for getCurrentUserID

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -381,7 +381,7 @@ class Util {
      */
     public static getCurrentUserID(): string {
         const myInfo = <HTMLAnchorElement>(
-            document.querySelector('.mmUserStats .avatar a')
+            document.querySelector('.mmUserStats .myInfo a')
         );
         if (myInfo) {
             const userID = <string>this.endOfHref(myInfo);


### PR DESCRIPTION
Hello, I noticed that the gift history wasn't working on the logged in user's info page. It seems the selector used in `getCurrentUserID` is out of  date because I couldn't find an element with a class of `.avatar`. I updated the selector to use `.myInfo` instead, and that seems to work alright.