### PR TITLE
Add a check for ratio text being "Inf."

### DIFF
--- a/src/modules/global.ts
+++ b/src/modules/global.ts
@@ -106,8 +106,10 @@ class MiniVaultInfo implements Feature {
         - Extract the number (with float) from the element
         - Fix the float to 2 decimal places (which converts it back into a string)
         - Convert the string back into a number so that we can convert it with`toLocaleString` to get commas back */
-        const num = Number(Util.extractFloat(ratioText)[0].toFixed(2)).toLocaleString();
-        ratioText.innerHTML = `${num} <img src="/pic/updownBig.png" alt="ratio">`;
+        if (!ratioText.textContent?.includes('Inf.')) {
+            const num = Number(Util.extractFloat(ratioText)[0].toFixed(2)).toLocaleString();
+            ratioText.innerHTML = `${num} <img src="/pic/updownBig.png" alt="ratio">`;
+        }
 
         // Turn the numeric portion of the vault link into a number
         let newText: number = parseInt(


### PR DESCRIPTION
Lets the "Shorten the Vault link & ratio text" option work for users with an "Inf." ratio value.